### PR TITLE
Add linter and plugin.yml

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -4,6 +4,11 @@ steps:
       docker-compose#v1.3.2:
         run: tests
 
+  - label: ":sparkles: Lint"
+    plugins:
+      plugin-linter#v1.0.0:
+        name: s3-secrets
+
   - label: "㊙️ git-credentials test"
     command: .buildkite/test_credentials.sh
     plugins:

--- a/plugin.json
+++ b/plugin.json
@@ -1,7 +1,0 @@
-{
-  "name": "S3 Secrets",
-  "description": "Expose build secrets stored in s3 to your jobs",
-  "author": "@lox",
-  "public": true,
-  "requirements": ["curl", "bash", "aws"]
-}

--- a/plugin.yml
+++ b/plugin.yml
@@ -1,0 +1,14 @@
+name: s3-secrets
+description: Expose build secrets stored in s3 to your jobs
+author: https://github.com/lox
+requirements:
+  - curl
+  - bash
+  - aws
+configuration:
+  properties:
+    bucket:
+      type: string
+  required:
+    - bucket
+  additionalProperties: false


### PR DESCRIPTION
This brings this plugin into the standard line. The one thing is though, the plugin linter refuses to allow this plugin to validate without a usage example in the readme.

Is it possible to use this as an actual plugin these days? Or is still just hooks that need to be sourced from an agent? If so, maybe we shouldn't call it a plugin?