### PR TITLE
eval ssh-agent -k

### DIFF
--- a/hooks/pre-exit
+++ b/hooks/pre-exit
@@ -2,5 +2,5 @@
 
 if [[ -n "${SSH_AGENT_PID:-}" ]] && ps -p "$SSH_AGENT_PID" &>/dev/null; then
   echo "~~~ Stopping ssh-agent ${SSH_AGENT_PID}"
-  ssh-agent -k
+  eval "$(ssh-agent -k)"
 fi


### PR DESCRIPTION
`ssh-agent -k` outputs commands to be `eval`d:

```
$ ssh-agent -k
unset SSH_AUTH_SOCK;
unset SSH_AGENT_PID;
echo Agent pid 40249 killed;
```

It should be wrapped in an eval, like `ssh-agent -s`:

```
$ eval "$(ssh-agent -s)"
Agent pid 40270
$ eval "$(ssh-agent -k)"
Agent pid 40270 killed
```