### PR TITLE
Fix broken git-credential test in CI

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -6,6 +6,3 @@ steps:
 
   - label: "㊙️ git-credentials test"
     command: .buildkite/test_credentials.sh
-    plugins:
-      ${BUILDKITE_REPO}#${BUILDKITE_COMMIT}:
-        bucket: "${TEST_BUCKET}"

--- a/.buildkite/test_credentials.sh
+++ b/.buildkite/test_credentials.sh
@@ -1,6 +1,15 @@
 #!/bin/bash
 set -eu
 
+export BUILDKITE_PLUGIN_S3_SECRETS_BUCKET=${TEST_BUCKET?}
+
+pre_exit() {
+  source hooks/pre-exit
+}
+
+trap pre_exit EXIT
+source hooks/environment
+
 if [[ -d example-private-repository ]] ; then
   rm -rf example-private-repository
 fi


### PR DESCRIPTION
When we moved this to a new repo name it it broke the git-credentials tests. This fixes them. 