### PR TITLE
Fix unbound AWS_DEFAULT_REGION in git credential helper

### DIFF
--- a/git-credential-s3-secrets
+++ b/git-credential-s3-secrets
@@ -1,6 +1,8 @@
 #!/bin/bash
 set -eu
 
+AWS_DEFAULT_REGION=${AWS_DEFAULT_REGION:-us-east-1}
+
 # The function creates global variables with the parsed results.
 # It returns 0 if parsing was successful or non-zero otherwise.
 #


### PR DESCRIPTION
L58 references an unbound variable `AWS_DEFAULT_REGION` and with `-u` set
this breaks the script.

```
$ /usr/local/buildkite-aws-stack/plugins/secrets/git-credential-s3-secrets my-bucket my-pipeline/git-credentials
/usr/local/buildkite-aws-stack/plugins/secrets/git-credential-s3-secrets: line 58: AWS_DEFAULT_REGION: unbound variable
```

`git-credentials` is working for me with this change.