### PR TITLE
Readme: fix s3 upload from stdin example

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,7 +79,7 @@ https://user:password@host/path/to/repo
 ```
 
 ```
-aws s3 cp --acl private --sse aws:kms <(echo "https://user:password@host/path/to/repo") "s3://${secrets_bucket}/git-credentials"
+echo "https://user:password@host/path/to/repo" | aws s3 cp --acl private --sse aws:kms - "s3://${secrets_bucket}/git-credentials"
 ```
 
 These are then exposed via a [gitcredential helper](https://git-scm.com/docs/gitcredentials) which will download the


### PR DESCRIPTION
The original fails with "warning: Skipping file /dev/fd/12 File is character special device, block special device, FIFO, or socket."