### PR TITLE
Show unexpected errors from head-object

### DIFF
--- a/hooks/environment
+++ b/hooks/environment
@@ -39,6 +39,9 @@ if [[ -n "$s3_bucket" ]] ; then
       echo "Downloaded ${#ssh_key} bytes of ssh key"
       add_ssh_private_key_to_agent "$ssh_key"
       key_found=1
+    elif [[ $? -eq 2 ]] ; then
+      echo "+++ :warning: Failed to check if $key exists" >&2;
+      exit 1
     fi
   done
 

--- a/lib/shared.bash
+++ b/lib/shared.bash
@@ -5,7 +5,14 @@ s3_exists() {
   local key="$2"
   local aws_s3_args=("--region=$AWS_DEFAULT_REGION")
 
-  if ! aws s3api head-object "${aws_s3_args[@]}" --bucket "$bucket" --key "$key" &>/dev/null ; then
+  output=$(aws s3api head-object "${aws_s3_args[@]}" --bucket "$bucket" --key "$key" 1>/dev/null)
+  exitcode=$?
+
+  # If we didn't get a Not Found or Forbidden then show the error and return exit code 2
+  if [[ $exitcode -ne 0 && "$output" =~ (Not Found|Forbidden)$ ]] ; then
+    echo "$output" >&2
+    return 2
+  elif [[ $exitcode -ne 0 ]] ; then
     return 1
   fi
 }

--- a/lib/shared.bash
+++ b/lib/shared.bash
@@ -5,11 +5,12 @@ s3_exists() {
   local key="$2"
   local aws_s3_args=("--region=$AWS_DEFAULT_REGION")
 
-  output=$(aws s3api head-object "${aws_s3_args[@]}" --bucket "$bucket" --key "$key" 1>/dev/null)
+  # capture just stderr
+  output=$(aws s3api head-object "${aws_s3_args[@]}" --bucket "$bucket" --key "$key" 2>&1 >/dev/null)
   exitcode=$?
 
   # If we didn't get a Not Found or Forbidden then show the error and return exit code 2
-  if [[ $exitcode -ne 0 && "$output" =~ (Not Found|Forbidden)$ ]] ; then
+  if [[ $exitcode -ne 0 && ! $output =~ (Not Found|Forbidden)$ ]] ; then
     echo "$output" >&2
     return 2
   elif [[ $exitcode -ne 0 ]] ; then

--- a/lib/shared.bash
+++ b/lib/shared.bash
@@ -28,14 +28,14 @@ s3_bucket_exists() {
 s3_download() {
   local bucket="$1"
   local key="$2"
-  local aws_s3_args=("--quiet" "--region=$AWS_DEFAULT_REGION")
+  local aws_s3_args=("--only-show-errors" "--region=$AWS_DEFAULT_REGION")
 
   if [[ "${BUILDKITE_USE_KMS:-true}" =~ ^(true|1)$ ]] ; then
     aws_s3_args+=("--sse" "aws:kms")
   fi
 
-  if ! aws s3 cp "${aws_s3_args[@]}" "s3://$1/$2" - ; then
-    exit 1
+  if ! aws s3 cp "${aws_s3_args[@]}" "s3://${bucket}/${key}" - ; then
+    return 1
   fi
 }
 

--- a/tests/run.bats
+++ b/tests/run.bats
@@ -7,12 +7,21 @@ load '/usr/local/lib/bats/load.bash'
 # export SSH_AGENT_STUB_DEBUG=/dev/tty
 # export GIT_STUB_DEBUG=/dev/tty
 
-generate_file_list() {
-  echo \'
-  for file in "$@" ; do
-    echo -e "2013-09-02 21:37:53\t10 ${file}\n"
-  done
-  echo \'
+@test "Show unexpected s3 errors" {
+  export BUILDKITE_PLUGIN_S3_SECRETS_BUCKET=my_secrets_bucket
+  export BUILDKITE_PLUGIN_S3_SECRETS_DUMP_ENV=true
+  export BUILDKITE_PIPELINE_SLUG=test
+
+  stub aws \
+    "s3api head-bucket --bucket my_secrets_bucket : echo Forbidden; exit 0" \
+    "s3api head-object --region=us-east-1 --bucket my_secrets_bucket --key test/private_ssh_key : echo Unexpected llamas >&2; exit 1"
+
+  run bash -c "$PWD/hooks/environment && $PWD/hooks/pre-exit"
+
+  assert_failure
+  assert_output --partial "Unexpected llamas"
+
+  unstub aws
 }
 
 @test "Load env file from s3 bucket" {
@@ -24,18 +33,18 @@ generate_file_list() {
 
   stub aws \
     "s3api head-bucket --bucket my_secrets_bucket : echo Forbidden; exit 0" \
-    "s3api head-object --region=us-east-1 --bucket my_secrets_bucket --key test/private_ssh_key : exit 1" \
-    "s3api head-object --region=us-east-1 --bucket my_secrets_bucket --key test/id_rsa_github : exit 1" \
+    "s3api head-object --region=us-east-1 --bucket my_secrets_bucket --key test/private_ssh_key : echo Forbidden >&2; exit 1" \
+    "s3api head-object --region=us-east-1 --bucket my_secrets_bucket --key test/id_rsa_github : echo Forbidden >&2; exit 1" \
     "s3api head-object --region=us-east-1 --bucket my_secrets_bucket --key private_ssh_key : exit 0" \
-    "s3 cp --quiet --region=us-east-1 --sse aws:kms s3://my_secrets_bucket/private_ssh_key - : echo secret material" \
-    "s3api head-object --region=us-east-1 --bucket my_secrets_bucket --key id_rsa_github : exit 1" \
+    "s3 cp --only-show-errors --region=us-east-1 --sse aws:kms s3://my_secrets_bucket/private_ssh_key - : echo secret material" \
+    "s3api head-object --region=us-east-1 --bucket my_secrets_bucket --key id_rsa_github : echo Forbidden >&2; exit 1" \
     "s3api head-object --region=us-east-1 --bucket my_secrets_bucket --key env : exit 0" \
-    "s3 cp --quiet --region=us-east-1 --sse aws:kms s3://my_secrets_bucket/env - : echo SECRET=24" \
-    "s3api head-object --region=us-east-1 --bucket my_secrets_bucket --key environment : exit 1" \
-    "s3api head-object --region=us-east-1 --bucket my_secrets_bucket --key test/env : exit 1" \
-    "s3api head-object --region=us-east-1 --bucket my_secrets_bucket --key test/environment : exit 1" \
-    "s3api head-object --region=us-east-1 --bucket my_secrets_bucket --key git-credentials : exit 1" \
-    "s3api head-object --region=us-east-1 --bucket my_secrets_bucket --key test/git-credentials : exit 1"
+    "s3 cp --only-show-errors --region=us-east-1 --sse aws:kms s3://my_secrets_bucket/env - : echo SECRET=24" \
+    "s3api head-object --region=us-east-1 --bucket my_secrets_bucket --key environment : echo Forbidden >&2; exit 1" \
+    "s3api head-object --region=us-east-1 --bucket my_secrets_bucket --key test/env : echo Forbidden >&2; exit 1" \
+    "s3api head-object --region=us-east-1 --bucket my_secrets_bucket --key test/environment : echo Forbidden >&2; exit 1" \
+    "s3api head-object --region=us-east-1 --bucket my_secrets_bucket --key git-credentials : echo Forbidden >&2; exit 1" \
+    "s3api head-object --region=us-east-1 --bucket my_secrets_bucket --key test/git-credentials : echo Forbidden >&2; exit 1"
 
   stub ssh-add \
     "- : echo added ssh key"
@@ -60,14 +69,14 @@ generate_file_list() {
 
   stub aws \
     "s3api head-bucket --bucket my_secrets_bucket : echo Forbidden; exit 0" \
-    "s3api head-object --region=us-east-1 --bucket my_secrets_bucket --key test/private_ssh_key : exit 1" \
-    "s3api head-object --region=us-east-1 --bucket my_secrets_bucket --key test/id_rsa_github : exit 1" \
-    "s3api head-object --region=us-east-1 --bucket my_secrets_bucket --key private_ssh_key : exit 1" \
-    "s3api head-object --region=us-east-1 --bucket my_secrets_bucket --key id_rsa_github : exit 1" \
-    "s3api head-object --region=us-east-1 --bucket my_secrets_bucket --key env : exit 1" \
-    "s3api head-object --region=us-east-1 --bucket my_secrets_bucket --key environment : exit 1" \
-    "s3api head-object --region=us-east-1 --bucket my_secrets_bucket --key test/env : exit 1" \
-    "s3api head-object --region=us-east-1 --bucket my_secrets_bucket --key test/environment : exit 1" \
+    "s3api head-object --region=us-east-1 --bucket my_secrets_bucket --key test/private_ssh_key : echo Forbidden >&2; exit 1" \
+    "s3api head-object --region=us-east-1 --bucket my_secrets_bucket --key test/id_rsa_github : echo Forbidden >&2; exit 1" \
+    "s3api head-object --region=us-east-1 --bucket my_secrets_bucket --key private_ssh_key : echo Forbidden >&2; exit 1" \
+    "s3api head-object --region=us-east-1 --bucket my_secrets_bucket --key id_rsa_github : echo Forbidden >&2; exit 1" \
+    "s3api head-object --region=us-east-1 --bucket my_secrets_bucket --key env : echo Forbidden >&2; exit 1" \
+    "s3api head-object --region=us-east-1 --bucket my_secrets_bucket --key environment : echo Forbidden >&2; exit 1" \
+    "s3api head-object --region=us-east-1 --bucket my_secrets_bucket --key test/env : echo Forbidden >&2; exit 1" \
+    "s3api head-object --region=us-east-1 --bucket my_secrets_bucket --key test/environment : echo Forbidden >&2; exit 1" \
     "s3api head-object --region=us-east-1 --bucket my_secrets_bucket --key git-credentials : exit 0" \
     "s3api head-object --region=us-east-1 --bucket my_secrets_bucket --key test/git-credentials : exit 0"
 


### PR DESCRIPTION
Some folks have reported sporadic failures when fetching their secrets, this shows unexpected errors on the `head-object` check which should surface them better and make troubleshooting possible.

To check this out in an elastic stack, you could have the following in your `bootstrap-script`:

```
rm -rf /usr/local/buildkite-aws-stack/plugins/secrets
git clone https://github.com/buildkite/elastic-ci-stack-s3-secrets-hooks.git /usr/local/buildkite-aws-stack/plugins/secrets
pushd /usr/local/buildkite-aws-stack/plugins/secrets
git checkout show-errors-from-head-object
popd
```
