### PR TITLE
add AWS_METADATA_SERVICE_NUM_ATTEMPTS env var

### DIFF
--- a/hooks/environment
+++ b/hooks/environment
@@ -7,6 +7,10 @@ basedir="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && cd .. && pwd )"
 # shellcheck disable=SC1090
 . "$basedir/lib/shared.bash"
 
+# For resiliency, increase the number of attempts to retrieve credentials for IAM roles
+# The default value is 1
+export AWS_METADATA_SERVICE_NUM_ATTEMPTS=3
+
 TMPDIR=${TMPDIR:-/tmp}
 AWS_DEFAULT_REGION=${AWS_DEFAULT_REGION:-us-east-1}
 


### PR DESCRIPTION
(hopefully) solves https://github.com/buildkite/elastic-ci-stack-for-aws/issues/637

Sometimes `awscli` fails to connect to the metadata server, erroring with the failure

```
Unable to locate credentials. You can configure credentials by running "aws configure".
```

`awscli` can be configured with [metadata_service_num_attempts](https://docs.aws.amazon.com/cli/latest/reference/configure/#configuration-variables), by setting the env var [AWS_METADATA_SERVICE_NUM_ATTEMPTS](https://docs.aws.amazon.com/cli/latest/topic/config-vars.html#credentials)

I think 3 attempts is fine (default is 1). There is also a configurable `metadata_service_timeout`, but `metadata_service_num_attempts` should suffice