### PR TITLE
Warn instead of fail when no SSH keys found in S3

### DIFF
--- a/hooks/environment
+++ b/hooks/environment
@@ -45,9 +45,10 @@ if [[ -n "$s3_bucket" ]] ; then
     fi
   done
 
-  if [[ -z "${key_found:-}" ]] && [[ "${BUILDKITE_REPO:-}" =~ ^git ]] ; then
-    echo "+++ :warning: Failed to find an SSH key in secret bucket" >&2;
-    exit 1
+  if [[ -z "${key_found:-}" ]] && [[ "${BUILDKITE_REPO:-}" =~ ^git@ ]] ; then
+    echo >&2 "+++ :warning: Failed to find an SSH key in secret bucket"
+    echo >&2 "The repository '$BUILDKITE_REPO' appears to use SSH for transport, but the elastic-ci-stack-s3-secrets-hooks plugin did not find any SSH keys in the $s3_bucket S3 bucket."
+    echo >&2 "See https://github.com/buildkite/elastic-ci-stack-for-aws#build-secrets for more information."
   fi
 
   env_paths=(


### PR DESCRIPTION
Don't hard-fail when there's no SSH keys found.  The hard-fail was intended to make debugging more obvious, rather than an obscure permission error during `git clone`. However there are legitimate use-cases for enabling this secrets plugin but not fetching an SSH key, for example any combination of:

- `git config url.<base>.insteadOf` can be used to rewrite a `git@...` repo to `https://...` with HTTPS credentials sourced some other way,
- a pipeline may be using the environment part of this secrets plugin, but not the SSH key part.
- an agent may run some pipelines that use this secrets plugin, and some that don't.

This patch;

- removes the `exit 1` hard failure,
- adjusts the BUILDKITE_REPO pattern to not match non-SSH `git://` URLs,
- elaborates on the warning message, with a link to documentation.

Closes #24