### PR TITLE
Print more output around downloading environment files

### DIFF
--- a/hooks/environment
+++ b/hooks/environment
@@ -65,6 +65,7 @@ if [[ -n "$s3_bucket" ]] ; then
   env_before="$(env | sort)"
 
   for key in ${env_paths[*]} ; do
+    echo "Checking ${key}" >&2
     if s3_exists "$s3_bucket" "$key" ; then
       echo "Downloading env file from ${key}" >&2;
       if ! envscript=$(s3_download "${s3_bucket}" "$key") ; then
@@ -75,6 +76,9 @@ if [[ -n "$s3_bucket" ]] ; then
       set -o allexport
       eval "$envscript"
       set +o allexport
+    elif [[ $? -eq 2 ]] ; then
+      echo "+++ :warning: Failed to check if $key exists" >&2;
+      exit 1
     fi
   done
 


### PR DESCRIPTION
We've got a customer who is finding that when they set a global environment file as well as a pipeline environment file, the pipeline environment file never gets evaluated. 

We can see that only the global environment file gets downloaded and evaluated but not why the script never gets to the pipeline environment file, hopefully this change will give us some more info about what is actually happening.