### PR TITLE
Don't exit if can't check env file

### DIFF
--- a/hooks/environment
+++ b/hooks/environment
@@ -44,7 +44,7 @@ if [[ -n "$s3_bucket" ]] ; then
       add_ssh_private_key_to_agent "$ssh_key"
       key_found=1
     elif [[ $? -eq 2 ]] ; then
-      echo "+++ :warning: Failed to check if $key exists" >&2;
+      echo "Failed to check if $key exists" >&2;
       exit 1
     fi
   done

--- a/hooks/environment
+++ b/hooks/environment
@@ -44,7 +44,7 @@ if [[ -n "$s3_bucket" ]] ; then
       add_ssh_private_key_to_agent "$ssh_key"
       key_found=1
     elif [[ $? -eq 2 ]] ; then
-      echo "Failed to check if $key exists" >&2;
+      echo "+++ :warning: Failed to check if $key exists" >&2;
       exit 1
     fi
   done

--- a/hooks/environment
+++ b/hooks/environment
@@ -77,7 +77,7 @@ if [[ -n "$s3_bucket" ]] ; then
       eval "$envscript"
       set +o allexport
     elif [[ $? -eq 2 ]] ; then
-      echo "+++ :warning: Failed to check if $key exists" >&2;
+      echo "Failed to check if $key exists" >&2;
     fi
   done
 

--- a/hooks/environment
+++ b/hooks/environment
@@ -78,7 +78,6 @@ if [[ -n "$s3_bucket" ]] ; then
       set +o allexport
     elif [[ $? -eq 2 ]] ; then
       echo "+++ :warning: Failed to check if $key exists" >&2;
-      exit 1
     fi
   done
 


### PR DESCRIPTION
if a customer doesn't have one of the env files specified, they don't care if it can't be checked.

Thanks @matthewd for pointing this out! 