### PR TITLE
🧹 early exit instead of indentation, unused grep_secrets removed.

### DIFF
--- a/hooks/environment
+++ b/hooks/environment
@@ -17,91 +17,93 @@ AWS_DEFAULT_REGION=${AWS_DEFAULT_REGION:-us-east-1}
 s3_bucket="${BUILDKITE_PLUGIN_S3_SECRETS_BUCKET:-}"
 s3_bucket_prefix="${BUILDKITE_PLUGIN_S3_SECRETS_BUCKET_PREFIX:-$BUILDKITE_PIPELINE_SLUG}"
 
-if [[ -n "$s3_bucket" ]] ; then
-  echo "~~~ Downloading secrets from :s3: $s3_bucket" >&2;
+if [[ -z "$s3_bucket" ]] ; then
+  exit 0
+fi
 
-  if ! s3_bucket_exists "$s3_bucket" ; then
-    echo "+++ :warning: Bucket $s3_bucket doesn't exist" >&2;
-    exit 1
-  fi
+echo "~~~ Downloading secrets from :s3: $s3_bucket" >&2;
 
-  ssh_key_paths=(
-    "$s3_bucket_prefix/private_ssh_key"
-    "$s3_bucket_prefix/id_rsa_github"
-    "private_ssh_key"
-    "id_rsa_github"
-  )
+if ! s3_bucket_exists "$s3_bucket" ; then
+  echo "+++ :warning: Bucket $s3_bucket doesn't exist" >&2;
+  exit 1
+fi
 
-  for key in ${ssh_key_paths[*]} ; do
-    echo "Checking ${key}" >&2
-    if s3_exists "$s3_bucket" "$key" ; then
-      echo "Found ${key}, downloading" >&2;
-      if ! ssh_key=$(s3_download "${s3_bucket}" "$key") ; then
-        echo "+++ :warning: Failed to download ssh-key $key" >&2;
-        exit 1
-      fi
-      echo "Downloaded ${#ssh_key} bytes of ssh key"
-      add_ssh_private_key_to_agent "$ssh_key"
-      key_found=1
-    elif [[ $? -eq 2 ]] ; then
-      echo "+++ :warning: Failed to check if $key exists" >&2;
+ssh_key_paths=(
+  "$s3_bucket_prefix/private_ssh_key"
+  "$s3_bucket_prefix/id_rsa_github"
+  "private_ssh_key"
+  "id_rsa_github"
+)
+
+for key in ${ssh_key_paths[*]} ; do
+  echo "Checking ${key}" >&2
+  if s3_exists "$s3_bucket" "$key" ; then
+    echo "Found ${key}, downloading" >&2;
+    if ! ssh_key=$(s3_download "${s3_bucket}" "$key") ; then
+      echo "+++ :warning: Failed to download ssh-key $key" >&2;
       exit 1
     fi
-  done
-
-  if [[ -z "${key_found:-}" ]] && [[ "${BUILDKITE_REPO:-}" =~ ^git@ ]] ; then
-    echo >&2 "+++ :warning: Failed to find an SSH key in secret bucket"
-    echo >&2 "The repository '$BUILDKITE_REPO' appears to use SSH for transport, but the elastic-ci-stack-s3-secrets-hooks plugin did not find any SSH keys in the $s3_bucket S3 bucket."
-    echo >&2 "See https://github.com/buildkite/elastic-ci-stack-for-aws#build-secrets for more information."
+    echo "Downloaded ${#ssh_key} bytes of ssh key"
+    add_ssh_private_key_to_agent "$ssh_key"
+    key_found=1
+  elif [[ $? -eq 2 ]] ; then
+    echo "+++ :warning: Failed to check if $key exists" >&2;
+    exit 1
   fi
+done
 
-  env_paths=(
-    "env"
-    "environment"
-    "${s3_bucket_prefix}/env"
-    "${s3_bucket_prefix}/environment"
-  )
+if [[ -z "${key_found:-}" ]] && [[ "${BUILDKITE_REPO:-}" =~ ^git@ ]] ; then
+  echo >&2 "+++ :warning: Failed to find an SSH key in secret bucket"
+  echo >&2 "The repository '$BUILDKITE_REPO' appears to use SSH for transport, but the elastic-ci-stack-s3-secrets-hooks plugin did not find any SSH keys in the $s3_bucket S3 bucket."
+  echo >&2 "See https://github.com/buildkite/elastic-ci-stack-for-aws#build-secrets for more information."
+fi
 
-  env_before="$(env | sort)"
+env_paths=(
+  "env"
+  "environment"
+  "${s3_bucket_prefix}/env"
+  "${s3_bucket_prefix}/environment"
+)
 
-  for key in ${env_paths[*]} ; do
-    echo "Checking ${key}" >&2
-    if s3_exists "$s3_bucket" "$key" ; then
-      echo "Downloading env file from ${key}" >&2;
-      if ! envscript=$(s3_download "${s3_bucket}" "$key") ; then
-        echo "+++ :warning: Failed to download env from $key" >&2;
-        exit 1
-      fi
-      echo "Evaluating ${#envscript} bytes of env"
-      set -o allexport
-      eval "$envscript"
-      set +o allexport
-    elif [[ $? -eq 2 ]] ; then
-      echo "Failed to check if $key exists" >&2;
+env_before="$(env | sort)"
+
+for key in ${env_paths[*]} ; do
+  echo "Checking ${key}" >&2
+  if s3_exists "$s3_bucket" "$key" ; then
+    echo "Downloading env file from ${key}" >&2;
+    if ! envscript=$(s3_download "${s3_bucket}" "$key") ; then
+      echo "+++ :warning: Failed to download env from $key" >&2;
+      exit 1
     fi
-  done
-
-  git_credentials_paths=(
-    "git-credentials"
-    "${s3_bucket_prefix}/git-credentials"
-  )
-
-  git_credentials=()
-
-  for key in ${git_credentials_paths[*]} ; do
-    if s3_exists "$s3_bucket" "$key" ; then
-      echo "Adding git-credentials in $key as a credential helper" >&2;
-      git_credentials+=("'credential.helper=$basedir/git-credential-s3-secrets ${s3_bucket} ${key}'")
-    fi
-  done
-
-  if [[ "${#git_credentials[@]}" -gt 0 ]] ; then
-    export GIT_CONFIG_PARAMETERS
-    GIT_CONFIG_PARAMETERS=$( IFS=' '; echo -n "${git_credentials[*]}" )
+    echo "Evaluating ${#envscript} bytes of env"
+    set -o allexport
+    eval "$envscript"
+    set +o allexport
+  elif [[ $? -eq 2 ]] ; then
+    echo "Failed to check if $key exists" >&2;
   fi
+done
 
-  if [[ "${BUILDKITE_PLUGIN_S3_SECRETS_DUMP_ENV:-}" =~ ^(true|1)$ ]] ; then
-    echo "~~~ Environment variables that were set" >&2;
-    comm -13 <(echo "$env_before") <(env | sort) || true
+git_credentials_paths=(
+  "git-credentials"
+  "${s3_bucket_prefix}/git-credentials"
+)
+
+git_credentials=()
+
+for key in ${git_credentials_paths[*]} ; do
+  if s3_exists "$s3_bucket" "$key" ; then
+    echo "Adding git-credentials in $key as a credential helper" >&2;
+    git_credentials+=("'credential.helper=$basedir/git-credential-s3-secrets ${s3_bucket} ${key}'")
   fi
+done
+
+if [[ "${#git_credentials[@]}" -gt 0 ]] ; then
+  export GIT_CONFIG_PARAMETERS
+  GIT_CONFIG_PARAMETERS=$( IFS=' '; echo -n "${git_credentials[*]}" )
+fi
+
+if [[ "${BUILDKITE_PLUGIN_S3_SECRETS_DUMP_ENV:-}" =~ ^(true|1)$ ]] ; then
+  echo "~~~ Environment variables that were set" >&2;
+  comm -13 <(echo "$env_before") <(env | sort) || true
 fi

--- a/lib/shared.bash
+++ b/lib/shared.bash
@@ -50,7 +50,3 @@ add_ssh_private_key_to_agent() {
   echo "Loading ssh-key into ssh-agent (pid ${SSH_AGENT_PID:-})" >&2;
   echo "$ssh_key" | env SSH_ASKPASS="/bin/false" ssh-add -
 }
-
-grep_secrets() {
-  grep -E 'private_ssh_key|id_rsa_github|env|environment|git-credentials$' "$@"
-}


### PR DESCRIPTION
- Unused `grep_secrets` function removed.
    - looks like it was never even used in the commit d7f96df07773bec972c7557fba6a996e2626135e that introduced it.
- Early exit for no bucket; avoid bulk indentation.
    - Best to view the resulting diff [with whitespace ignored](https://github.com/buildkite/elastic-ci-stack-s3-secrets-hooks/pull/35/files?w=1).