### PR TITLE
2–3x speed-up: batch all s3_exists into parallel calls

### DIFF
--- a/hooks/environment
+++ b/hooks/environment
@@ -34,9 +34,23 @@ ssh_key_paths=(
   "private_ssh_key"
   "id_rsa_github"
 )
+env_paths=(
+  "env"
+  "environment"
+  "${s3_bucket_prefix}/env"
+  "${s3_bucket_prefix}/environment"
+)
+git_credentials_paths=(
+  "git-credentials"
+  "${s3_bucket_prefix}/git-credentials"
+)
+
+s3_exists_preload "$s3_bucket" \
+  "${ssh_key_paths[@]}" \
+  "${env_paths[@]}" \
+  "${git_credentials_paths[@]}"
 
 for key in ${ssh_key_paths[*]} ; do
-  echo "Checking ${key}" >&2
   if s3_exists "$s3_bucket" "$key" ; then
     echo "Found ${key}, downloading" >&2;
     if ! ssh_key=$(s3_download "${s3_bucket}" "$key") ; then
@@ -58,17 +72,9 @@ if [[ -z "${key_found:-}" ]] && [[ "${BUILDKITE_REPO:-}" =~ ^git@ ]] ; then
   echo >&2 "See https://github.com/buildkite/elastic-ci-stack-for-aws#build-secrets for more information."
 fi
 
-env_paths=(
-  "env"
-  "environment"
-  "${s3_bucket_prefix}/env"
-  "${s3_bucket_prefix}/environment"
-)
-
 env_before="$(env | sort)"
 
 for key in ${env_paths[*]} ; do
-  echo "Checking ${key}" >&2
   if s3_exists "$s3_bucket" "$key" ; then
     echo "Downloading env file from ${key}" >&2;
     if ! envscript=$(s3_download "${s3_bucket}" "$key") ; then
@@ -83,11 +89,6 @@ for key in ${env_paths[*]} ; do
     echo "Failed to check if $key exists" >&2;
   fi
 done
-
-git_credentials_paths=(
-  "git-credentials"
-  "${s3_bucket_prefix}/git-credentials"
-)
 
 git_credentials=()
 

--- a/lib/shared.bash
+++ b/lib/shared.bash
@@ -1,9 +1,61 @@
 #!/bin/bash
 
+declare -a s3_cache_found
+declare -a s3_cache_not_found
+
+s3_exists_preload() {
+  local bucket="$1"; shift
+  local keys=("$@")
+
+  echo >&2 "Searching $bucket"
+  declare -a pid_to_cache_key
+  declare -a pid_to_key
+  for key in "${keys[@]}"; do
+    cache_key="$bucket/$key"
+    s3_exists "$bucket" "$key" &
+    pid=$!
+    pid_to_cache_key[$pid]="$cache_key"
+    pid_to_key[$pid]="$key"
+  done
+  declare -a keys_found
+  declare -a keys_not_found
+  for pid in "${!pid_to_cache_key[@]}"; do
+    cache_key=${pid_to_cache_key[$pid]}
+    key=${pid_to_key[$pid]}
+    if wait "$pid"; then
+      s3_cache_found+=("$cache_key")
+      keys_found+=("$key")
+    else
+      s3_cache_not_found+=("$cache_key")
+      keys_not_found+=("$key")
+    fi
+  done
+  echo >&2 "Found:"
+  for key in "${keys_found[@]}"; do
+    echo >&2 "- $key"
+  done
+  echo >&2 "Not found:"
+  for key in "${keys_not_found[@]}"; do
+    echo >&2 "- $key"
+  done
+}
+
 s3_exists() {
   local bucket="$1"
   local key="$2"
   local aws_s3_args=("--region=$AWS_DEFAULT_REGION")
+
+  cache_key="$bucket/$key"
+  for found in "${s3_cache_found[@]-}"; do
+    if [[ $found == "$cache_key" ]]; then
+      return 0
+    fi
+  done
+  for not_found in "${s3_cache_not_found[@]-}"; do
+    if [[ $not_found == "$cache_key" ]]; then
+      return 1
+    fi
+  done
 
   # capture just stderr
   output=$(aws s3api head-object "${aws_s3_args[@]}" --bucket "$bucket" --key "$key" 2>&1 >/dev/null)


### PR DESCRIPTION
Ten S3 object existence checks are parallelised instead of running sequentially.
21 seconds reduced to 7 seconds in my local environment.
Caveat: my round-trip latency is higher than within AWS.

This pull request introduces a `s3_exists_preload` function, which takes a list of all S3 keys and checks for existence in parallel. The results are cached for use in the regular `s3_exists` function.

- [ ] Somehow get the brittle BATS test suite passing.

Before:

    ~~~ Downloading secrets from :s3: buildkite-sandbox-pda-test
    Checking bar/private_ssh_key
    Checking bar/id_rsa_github
    Checking private_ssh_key
    Checking id_rsa_github
    Checking env
    Checking environment
    Downloading env file from environment
    Evaluating 13 bytes of env
    Checking bar/env
    Downloading env file from bar/env
    Evaluating 11 bytes of env
    Checking bar/environment
    ./hooks/environment  4.82s user 1.25s system 28% cpu 21.465 total

After:

    ~~~ Downloading secrets from :s3: buildkite-sandbox-pda-test
    Searching buildkite-sandbox-pda-test
    Found:
    - environment
    - bar/env
    Not found:
    - bar/private_ssh_key
    - bar/id_rsa_github
    - private_ssh_key
    - id_rsa_github
    - env
    - bar/environment
    - git-credentials
    - bar/git-credentials
    Downloading env file from environment
    Evaluating 13 bytes of env
    Downloading env file from bar/env
    Evaluating 11 bytes of env
    ./hooks/environment  7.61s user 2.10s system 133% cpu 7.275 total