### PR TITLE
Append a trailing newline to secret keys before sending them to the ssh-agent

### DIFF
--- a/s3secrets-helper/sshagent/sshagent.go
+++ b/s3secrets-helper/sshagent/sshagent.go
@@ -77,6 +77,7 @@ func (a *Agent) Add(key []byte) error {
 		return errors.New("Agent must Run() before Add()")
 	}
 	cmd := exec.Command("ssh-add", "-")
+	key = append(key, '\n')
 	cmd.Stdin = bytes.NewReader(key)
 	cmd.Env = []string{
 		"SSH_AGENT_PID=" + strconv.Itoa(a.pid),


### PR DESCRIPTION
Testing shows this works for both keys with and without trailing newlines already.

Fixes #43 