### PR TITLE
Fix credential.helper path when it includes spaces

### DIFF
--- a/s3secrets-helper/secrets/secrets.go
+++ b/s3secrets-helper/secrets/secrets.go
@@ -205,20 +205,29 @@ func handleGitCredentials(conf Config, results <-chan getResult) error {
 			continue
 		}
 		log.Printf("Adding git-credentials in %s/%s as a credential helper", r.bucket, r.key)
-		helpers = append(helpers, fmt.Sprintf(
-			"credential.helper=%s %s %s",
-			conf.GitCredentialHelper, r.bucket, r.key,
-		))
+
+		// Replace spaces ' ' in the helper path with an escaped space '\ '
+		escapedCredentialHelper := strings.ReplaceAll(conf.GitCredentialHelper, " ", "\\ ")
+
+		helper := fmt.Sprintf("credential.helper=%s %s %s", escapedCredentialHelper, r.bucket, r.key)
+
+		helpers = append(helpers, helper)
 	}
 	if len(helpers) == 0 {
 		return nil
 	}
 
+	// Build an environment variable for interpretation by a shell
 	var singleQuotedHelpers []string
-	for helper := range helpers {
+	for _, helper := range helpers {
+		// Escape any escape sequences, the shell will interpret the first level
+		// of escaping.
+
+		// Replace backslash '\' with double backslash '\\'
+		helper = strings.ReplaceAll(helper, "\\", "\\\\")
+
 		singleQuotedHelpers = append(singleQuotedHelpers, "'" + helper + "'")
 	}
-
 	env := "GIT_CONFIG_PARAMETERS=\"" + strings.Join(singleQuotedHelpers, " ") + "\"\n"
 
 	if _, err := io.WriteString(conf.EnvSink, env); err != nil {

--- a/s3secrets-helper/secrets/secrets.go
+++ b/s3secrets-helper/secrets/secrets.go
@@ -206,14 +206,21 @@ func handleGitCredentials(conf Config, results <-chan getResult) error {
 		}
 		log.Printf("Adding git-credentials in %s/%s as a credential helper", r.bucket, r.key)
 		helpers = append(helpers, fmt.Sprintf(
-			"'credential.helper=%s %s %s'",
+			"credential.helper=%s %s %s",
 			conf.GitCredentialHelper, r.bucket, r.key,
 		))
 	}
 	if len(helpers) == 0 {
 		return nil
 	}
-	env := "GIT_CONFIG_PARAMETERS=\"" + strings.Join(helpers, " ") + "\"\n"
+
+	var singleQuotedHelpers []string
+	for helper := range helpers {
+		singleQuotedHelpers = append(singleQuotedHelpers, "'" + helper + "'")
+	}
+
+	env := "GIT_CONFIG_PARAMETERS=\"" + strings.Join(singleQuotedHelpers, " ") + "\"\n"
+
 	if _, err := io.WriteString(conf.EnvSink, env); err != nil {
 		return fmt.Errorf("writing GIT_CONFIG_PARAMETERS env: %w", err)
 	}


### PR DESCRIPTION
Escaping the program path adequately (twice!) should fix this issue.

- [x] Test built binary on Windows
- [x] Test built binary on Linux

Fixes #46