### PR TITLE
Assume an IAM role to run integration tests

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -79,6 +79,9 @@ steps:
 
   - label: "㊙️ git-credentials test"
     command: .buildkite/test_credentials.sh
+    plugins:
+      - aws-assume-role-with-web-identity#v1.1.0:
+          role-arn: arn:aws:iam::172840064832:role/pipeline-buildkite-aws-stack-elastic-ci-stack-s3-secrets-hooks
 
   - wait
 


### PR DESCRIPTION
This step runs an integration test, confirming the compiled plugin helper is able to read a git-credentials file from a real S3 bucket (bucket name is set in an ENV).

It's been a few years since this project was actively developed, however it's still very much used in current elastic stack releases. The test setup has bitrot a little, and the current agents don't have permission to read the test S3 bucket.

Rather than add the required permissions to the Instance Role used by the current agents, I've created an OIDC assumable role that has the rquired S3 permissions. The role is only assumable by this pipeline.