### PR TITLE
tweak dependabot config

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -7,7 +7,13 @@ updates:
     open-pull-requests-limit: 2
     reviewers:
       - "buildkite/agent-stewards"
+    groups:
+      aws:
+        patterns:
+        - github.com/aws/*
   - package-ecosystem: docker
     directory: /.buildkite
     schedule:
       interval: monthly
+    reviewers:
+      - "buildkite/agent-stewards"


### PR DESCRIPTION
A couple of things I noticed once #61 started working

* group all updates to the AWS sdk modules (to avoid partial updates like #64)
* tag agent-stewards as reviewers for docker PRs