### PR TITLE
Switch release step back to standard agents

### DIFF
--- a/.buildkite/Dockerfile-release
+++ b/.buildkite/Dockerfile-release
@@ -1,0 +1,5 @@
+FROM debian:bookworm-slim
+
+ADD https://github.com/buildkite/github-release/releases/download/v1.0/github-release-linux-amd64 /usr/local/bin/github-release
+RUN chmod +x /usr/local/bin/github-release
+RUN apt update && apt install -y ca-certificates

--- a/.buildkite/docker-compose.yml
+++ b/.buildkite/docker-compose.yml
@@ -11,3 +11,9 @@ services:
     environment:
       - GOOS
       - GOARCH
+  release:
+    build:
+      dockerfile: Dockerfile-release
+      context: .
+    volumes:
+      - ../:/work:cached

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -98,6 +98,16 @@ steps:
     command: ".buildkite/steps/github-release.sh"
     branches:
       - main
-    agents:
-      queue: "on-demand"
-      task-definition: github-publish-buildkite-elastic-stack-releaser
+    plugins:
+      - aws-assume-role-with-web-identity#v1.1.0:
+          role-arn: arn:aws:iam::172840064832:role/pipeline-buildkite-aws-stack-elastic-ci-stack-s3-secrets-hooks-main
+      - aws-ssm#v1.0.0:
+          parameters:
+            GITHUB_RELEASE_ACCESS_TOKEN: /pipelines/buildkite-aws-stack/elastic-ci-stack-s3-secrets-hooks/GITHUB_RELEASE_ACCESS_TOKEN
+      - docker-compose#v3.7.0:
+          config: .buildkite/docker-compose.yml
+          run: release
+          mount-buildkite-agent: true
+          env:
+            - GITHUB_RELEASE_ACCESS_TOKEN
+

--- a/.buildkite/steps/github-release.sh
+++ b/.buildkite/steps/github-release.sh
@@ -12,6 +12,12 @@ then
 	exit 1
 fi
 
+if [ -z "${GITHUB_RELEASE_ACCESS_TOKEN}" ]
+then
+  echo "Error: Missing \$GITHUB_RELEASE_ACCESS_TOKEN"
+  exit 1
+fi
+
 echo '--- Downloading releases'
 
 rm -rf pkg
@@ -20,4 +26,6 @@ buildkite-agent artifact download "pkg/*" .
 
 echo '--- Creating GitHub Release'
 
-github-release "${VERSION}" pkg/* --commit "$(git rev-parse HEAD)" --github-repository "buildkite/elastic-ci-stack-s3-secrets-hooks"
+export GITHUB_RELEASE_REPOSITORY="buildkite/elastic-ci-stack-s3-secrets-hooks"
+
+github-release "${VERSION}" pkg/* --commit "$(git rev-parse HEAD)"


### PR DESCRIPTION
This is a partial revert of commit 90deee4f84d2bf41d8b46ac439ad934605f557f3.

In that commit we changed the release step to run on an experimental agent queue called "on-demand". That queue doesn't exist any more, so releasing is broken.

I've reverted it, but then made some additional changes. Back in 2021 the release step ran on our deploy agents, which had privileged access. That's no longer a pattern we use, so we want to:

* run the step on an standard unprivileged agent
* assume an IAM role via OIDC that has just the permissions we require
* use docker to define the build tools we need

I'm ~80% confident this will just work. it's difficult  to test, because the IAM role can only be assumed by builds that are on `main`. However, I've run a few partial builds on the branch to confirm the docker container starts and has github-release available, so that bit at least I'm sure works. Merge it and find out?