### PR TITLE
Set working_dir for release step

### DIFF
--- a/.buildkite/docker-compose.yml
+++ b/.buildkite/docker-compose.yml
@@ -17,3 +17,4 @@ services:
       context: .
     volumes:
       - ../:/work:cached
+    working_dir: /work


### PR DESCRIPTION
When creating a release on Github, we need the docker container to have the repository directory as the PWD. That will mean we can run `.buildkite/steps/github-release.sh` in pipeline.yml and it should Just Work

This should avoid errors like [1]:

    /bin/sh: 1: .buildkite/steps/github-release.sh: not found

[1] https://buildkite.com/buildkite-aws-stack/elastic-ci-stack-s3-secrets-hooks/builds/85#0193b446-ed45-4803-9563-c705b4437150