### PR TITLE
Feat/add multiple secret file support

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,12 @@ Different types of secrets are supported and exposed to your builds in appropria
 - `ssh-agent` for SSH Private Keys
 - Environment Variables for strings
 - `git-credential` via git's credential.helper
+- Other secrets, which must be suffixed with one of the following:
+  - `_SECRET`
+  - `_SECRET_KEY`
+  - `_PASSWORD`
+  - `_TOKEN`
+  - `_ACCESS_KEY`
 
 ## Installation
 
@@ -55,9 +61,10 @@ When run via the agent environment and pre-exit hook, your builds will check in 
 - `s3://{bucket_name}/private_ssh_key`
 - `s3://{bucket_name}/environment` or `s3://{bucket_name}/env`
 - `s3://{bucket_name}/git-credentials`
+- `s3://{bucket_name}/secret-files/`
 
 The private key is exposed to both the checkout and the command as an ssh-agent instance.
-The secrets in the env file are exposed as environment variables.
+The secrets in the env file are exposed as environment variables, as are individual secret files.
 The locations of git-credentials are passed via `GIT_CONFIG_PARAMETERS` environment to git.
 
 ## Uploading Secrets
@@ -98,6 +105,16 @@ Key values pairs can also be uploaded.
 
 ```bash
 aws s3 cp --acl private --sse aws:kms <(echo "MY_SECRET=blah") "s3://${secrets_bucket}/environment"
+```
+
+### Individual Secrets
+
+Individual secrets with a suffix of `_SECRET`, `_SECRET_KEY`, `_PASSWORD`, `_TOKEN`, or `_ACCESS_KEY` can be uploaded to the same location as the rest of your configuration, under an additional prefix of `/secret-files/`.
+
+The file contents should be the secret value, and the object key becomes the environment variable name. For example:
+
+```bash
+aws s3 cp --acl private --sse aws:kms <(echo "<SECRET_VALUE>") "s3://${secrets_bucket}/secret-files/SPECIAL_SECRET"
 ```
 
 ## Options

--- a/s3secrets-helper/s3/s3.go
+++ b/s3secrets-helper/s3/s3.go
@@ -143,9 +143,13 @@ func (c *Client) ListSuffix(prefix string, suffixes []string) ([]string, error) 
 	for i, object := range resp.Contents {
 		for _, suffix := range suffixes {
 			if strings.HasSuffix(*object.Key, suffix) {
-				keys = append(keys, *object.Key)
-				resp.Contents = append(resp.Contents[:i], resp.Contents[i+1:]...) //since we have a match, pop it
-				break                                                             //... then break out of the suffix loop
+				if i < len(resp.Contents)-1 {
+					keys = append(keys, *object.Key)
+					resp.Contents = append(resp.Contents[:i], resp.Contents[i+1:]...) //since we have a match, pop it
+					break                                                             //... then break out of the suffix loop
+				} else {
+					keys = append(keys, *object.Key) // No need to pop the object as we are at the end of the list
+				} //... then break out of the suffix loop
 			}
 		}
 	}

--- a/s3secrets-helper/s3/s3.go
+++ b/s3secrets-helper/s3/s3.go
@@ -140,16 +140,11 @@ func (c *Client) ListSuffix(prefix string, suffixes []string) ([]string, error) 
 	})
 
 	// Iterate over all objects at the prefix and find those who match our suffix
-	for i, object := range resp.Contents {
+	for _, object := range resp.Contents {
 		for _, suffix := range suffixes {
 			if strings.HasSuffix(*object.Key, suffix) {
-				if i < len(resp.Contents)-1 {
-					keys = append(keys, *object.Key)
-					resp.Contents = append(resp.Contents[:i], resp.Contents[i+1:]...) //since we have a match, pop it
-					break                                                             //... then break out of the suffix loop
-				} else {
-					keys = append(keys, *object.Key) // No need to pop the object as we are at the end of the list
-				} //... then break out of the suffix loop
+				keys = append(keys, *object.Key)
+				break //break out of the suffix loop
 			}
 		}
 	}

--- a/s3secrets-helper/secrets/secrets.go
+++ b/s3secrets-helper/secrets/secrets.go
@@ -12,9 +12,10 @@ import (
 
 // Client represents interaction with AWS S3
 type Client interface {
-	Bucket() (string)
-	Region() (string)
+	Bucket() string
+	Region() string
 	Get(key string) ([]byte, error)
+	ListSuffix(prefix string, suffix []string) ([]string, error)
 	BucketExists() (bool, error)
 }
 
@@ -52,6 +53,10 @@ type Config struct {
 
 	// GitCredentialHelper is the path to git-credential-s3-secrets
 	GitCredentialHelper string
+
+	// Secret suffixes to look for in S3.
+	// Defaults to "_SECRET", "_SECRET_KEY", "_PASSWORD", "_TOKEN", and "_ACCESS_KEY"
+	SecretSuffixes []string
 }
 
 // Run is the programmatic (as opposed to CLI) entrypoint to all
@@ -81,6 +86,9 @@ func Run(conf Config) error {
 	resultsGit := make(chan getResult)
 	getGitCredentials(conf, resultsGit)
 
+	resultsSecrets := make(chan getResult)
+	getSecrets(conf, resultsSecrets)
+
 	if err := handleSSHKeys(conf, resultsSSH); err != nil {
 		return err
 	}
@@ -88,6 +96,9 @@ func Run(conf Config) error {
 		return err
 	}
 	if err := handleGitCredentials(conf, resultsGit); err != nil {
+		return err
+	}
+	if err := handleSecrets(conf, resultsSecrets); err != nil {
 		return err
 	}
 	return nil
@@ -117,6 +128,21 @@ func getEnvs(conf Config, results chan<- getResult) {
 	conf.Logger.Printf("Checking S3 for environment files:")
 	for _, k := range keys {
 		conf.Logger.Printf("- %s", k)
+	}
+	go GetAll(conf.Client, conf.Client.Bucket(), keys, results)
+}
+
+func getSecrets(conf Config, results chan<- getResult) {
+	suffixes := append(conf.SecretSuffixes, []string{
+		"_SECRET",
+		"_SECRET_KEY",
+		"_PASSWORD",
+		"_TOKEN",
+		"_ACCESS_KEY",
+	}...)
+	keys, err := conf.Client.ListSuffix(conf.Prefix, suffixes)
+	if err != nil {
+		fmt.Errorf("listing matching secrets: %w", err)
 	}
 	go GetAll(conf.Client, conf.Client.Bucket(), keys, results)
 }
@@ -227,12 +253,46 @@ func handleGitCredentials(conf Config, results <-chan getResult) error {
 		// Replace backslash '\' with double backslash '\\'
 		helper = strings.ReplaceAll(helper, "\\", "\\\\")
 
-		singleQuotedHelpers = append(singleQuotedHelpers, "'" + helper + "'")
+		singleQuotedHelpers = append(singleQuotedHelpers, "'"+helper+"'")
 	}
 	env := "GIT_CONFIG_PARAMETERS=\"" + strings.Join(singleQuotedHelpers, " ") + "\"\n"
 
 	if _, err := io.WriteString(conf.EnvSink, env); err != nil {
 		return fmt.Errorf("writing GIT_CONFIG_PARAMETERS env: %w", err)
+	}
+	return nil
+}
+
+// handleSecrets loads secrets into the environment.
+// The key is the last part of the S3 key.
+func handleSecrets(conf Config, results <-chan getResult) error {
+	log := conf.Logger
+	// Build an environment variable for interpretation by a shell
+	var singleQuotedSecrets []string
+	var envString string
+	for r := range results {
+		if r.err != nil {
+			if r.err != sentinel.ErrNotFound && r.err != sentinel.ErrForbidden {
+				log.Printf("+++ :warning: Failed to download secret %s/%s: %v", r.bucket, r.key, r.err)
+			}
+			continue
+		}
+		log.Printf("Adding secret %s/%s to environment", r.bucket, r.key)
+		envKey := strings.Split(r.key, "/")[len(strings.Split(r.key, "/"))-1]
+
+		// Replace backslash '\' with double backslash '\\'
+		value := strings.ReplaceAll(string(r.data), "\\", "\\\\")
+
+		singleQuotedSecrets = append(singleQuotedSecrets, envKey+"='"+value+"'")
+
+	}
+	if len(singleQuotedSecrets) == 0 {
+		log.Printf("No secrets found in %q", conf.Prefix)
+		return nil
+	}
+	envString = strings.Join(singleQuotedSecrets, "\n") + "\n"
+	if _, err := io.WriteString(conf.EnvSink, envString); err != nil {
+		return fmt.Errorf("writing SECRETS to env: %w", err)
 	}
 	return nil
 }

--- a/s3secrets-helper/secrets/secrets.go
+++ b/s3secrets-helper/secrets/secrets.go
@@ -140,7 +140,8 @@ func getSecrets(conf Config, results chan<- getResult) {
 		"_TOKEN",
 		"_ACCESS_KEY",
 	}...)
-	keys, err := conf.Client.ListSuffix(conf.Prefix, suffixes)
+	secretPrefix := conf.Prefix + "/secret-files"
+	keys, err := conf.Client.ListSuffix(secretPrefix, suffixes)
 	if err != nil {
 		fmt.Errorf("listing matching secrets: %w", err)
 	}

--- a/s3secrets-helper/secrets/secrets_test.go
+++ b/s3secrets-helper/secrets/secrets_test.go
@@ -46,7 +46,7 @@ func (c *FakeClient) Bucket() string {
 }
 
 func (c *FakeClient) ListSuffix(prefix string, suffix []string) ([]string, error) {
-	fakeSecrets := []string{"pipeline/BUILDKITE_ACCESS_KEY", "pipeline/DATABASE_SECRET", "pipeline/EXTERNAL_API_SECRET_KEY", "pipeline/PRIVILEGED_PASSWORD", "pipeline/SERVICE_TOKEN"}
+	fakeSecrets := []string{"pipeline/secret-files/BUILDKITE_ACCESS_KEY", "pipeline/secret-files/DATABASE_SECRET", "pipeline/secret-files/EXTERNAL_API_SECRET_KEY", "pipeline/secret-files/PRIVILEGED_PASSWORD", "pipeline/secret-files/SERVICE_TOKEN"}
 	return fakeSecrets, nil
 }
 
@@ -106,11 +106,11 @@ func TestRun(t *testing.T) {
 		"bkt/git-credentials":          {[]byte("general git key"), nil},
 		"bkt/pipeline/git-credentials": {[]byte("pipeline git key"), nil},
 
-		"bkt/pipeline/BUILDKITE_ACCESS_KEY":    {[]byte("buildkite access key"), nil},
-		"bkt/pipeline/DATABASE_SECRET":         {[]byte("database secret"), nil},
-		"bkt/pipeline/EXTERNAL_API_SECRET_KEY": {[]byte("external api secret"), nil},
-		"bkt/pipeline/PRIVILEGED_PASSWORD":     {[]byte("privileged password"), nil},
-		"bkt/pipeline/SERVICE_TOKEN":           {[]byte("service token"), nil},
+		"bkt/pipeline/secret-files/BUILDKITE_ACCESS_KEY":    {[]byte("buildkite access key"), nil},
+		"bkt/pipeline/secret-files/DATABASE_SECRET":         {[]byte("database secret"), nil},
+		"bkt/pipeline/secret-files/EXTERNAL_API_SECRET_KEY": {[]byte("external api secret"), nil},
+		"bkt/pipeline/secret-files/PRIVILEGED_PASSWORD":     {[]byte("privileged password"), nil},
+		"bkt/pipeline/secret-files/SERVICE_TOKEN":           {[]byte("service token"), nil},
 	}
 	logbuf := &bytes.Buffer{}
 	fakeAgent := &FakeAgent{t: t}

--- a/s3secrets-helper/secrets/secrets_test.go
+++ b/s3secrets-helper/secrets/secrets_test.go
@@ -89,8 +89,20 @@ func TestRun(t *testing.T) {
 		"bkt/pipeline/env":         {nil, sentinel.ErrNotFound},
 		"bkt/pipeline/environment": {[]byte("C=three"), nil},
 
+		"bkt/pipeline/BUILDKITE_ACCESS_KEY":    {[]byte("buildkite access key"), nil},
+		"bkt/pipeline/DATABASE_SECRET":         {[]byte("database secret"), nil},
+		"bkt/pipeline/EXTERNAL_API_SECRET_KEY": {[]byte("external api secret"), nil},
+		"bkt/pipeline/PRIVILEGED_PASSWORD":     {[]byte("privileged password"), nil},
+		"bkt/pipeline/SERVICE_TOKEN":           {[]byte("service token"), nil},
+
 		"bkt/git-credentials":          {[]byte("general git key"), nil},
 		"bkt/pipeline/git-credentials": {[]byte("pipeline git key"), nil},
+
+		"bkt/pipeline/BUILDKITE_ACCESS_KEY":    {[]byte("buildkite access key"), nil},
+		"bkt/pipeline/DATABASE_SECRET":         {[]byte("database secret"), nil},
+		"bkt/pipeline/EXTERNAL_API_SECRET_KEY": {[]byte("external api secret"), nil},
+		"bkt/pipeline/PRIVILEGED_PASSWORD":     {[]byte("privileged password"), nil},
+		"bkt/pipeline/SERVICE_TOKEN":           {[]byte("service token"), nil},
 	}
 	logbuf := &bytes.Buffer{}
 	fakeAgent := &FakeAgent{t: t}
@@ -130,7 +142,13 @@ func TestRun(t *testing.T) {
 		// because git-credentials were found:
 		// (wrap in double quotes so that bash eval doesn't consume the inner single quote.
 		`GIT_CONFIG_PARAMETERS="` + gitCredentialHelpers + `"`,
+		"BUILDKITE_ACCESS_KEY='buildkite access key'",
+		"DATABASE_SECRET='database secret'",
+		"EXTERNAL_API_SECRET_KEY='external api secret'",
+		"PRIVILEGED_PASSWORD='privileged password'",
+		"SERVICE_TOKEN='service token'",
 	}, "\n") + "\n"
+
 	if actual := envSink.String(); expected != actual {
 		t.Errorf("unexpected env written:\n-%q\n+%q", expected, actual)
 	}

--- a/s3secrets-helper/secrets/secrets_test.go
+++ b/s3secrets-helper/secrets/secrets_test.go
@@ -5,9 +5,7 @@ import (
 	"errors"
 	"io"
 	"log"
-	"maps"
 	"math/rand"
-	"os"
 	"reflect"
 	"strings"
 	"testing"
@@ -94,13 +92,6 @@ echo Agent pid 42
 }
 
 func TestRun(t *testing.T) {
-	fakeSecretsData := map[string]FakeObject{
-		"bkt/pipeline/BUILDKITE_ACCESS_KEY":    {[]byte("buildkite access key"), nil},
-		"bkt/pipeline/DATABASE_SECRET":         {[]byte("database secret"), nil},
-		"bkt/pipeline/EXTERNAL_API_SECRET_KEY": {[]byte("external api secret"), nil},
-		"bkt/pipeline/PRIVILEGED_PASSWORD":     {[]byte("privileged password"), nil},
-		"bkt/pipeline/SERVICE_TOKEN":           {[]byte("service token"), nil},
-	}
 	fakeData := map[string]FakeObject{
 		"bkt/pipeline/private_ssh_key": {nil, sentinel.ErrNotFound},
 		"bkt/pipeline/id_rsa_github":   {[]byte("pipeline key"), nil},
@@ -121,7 +112,6 @@ func TestRun(t *testing.T) {
 		"bkt/pipeline/PRIVILEGED_PASSWORD":     {[]byte("privileged password"), nil},
 		"bkt/pipeline/SERVICE_TOKEN":           {[]byte("service token"), nil},
 	}
-	maps.Copy(fakeData, fakeSecretsData)
 	logbuf := &bytes.Buffer{}
 	fakeAgent := &FakeAgent{t: t}
 	envSink := &bytes.Buffer{}
@@ -170,7 +160,6 @@ func TestRun(t *testing.T) {
 	if actual := envSink.String(); expected != actual {
 		t.Errorf("unexpected env written:\n-%q\n+%q", expected, actual)
 	}
-	assertEnvMapping(t, fakeSecretsData, makeEnvMap(os.Environ()))
 	t.Logf("hook log:\n%s", logbuf.String())
 }
 


### PR DESCRIPTION
This PR adds support for placing secret files in S3, as defined in #60.

To re-summarise, this allows for the placement of individual files in the S3 bucket where configuration files are being kept, and based on these files having an identifying suffix, downloading the files and injecting the contents into environment variables, through the same environment variable string construction for environment files and Git credentials helpers.

I have also updated the tests for this in a subsequent commit, because they appeared to not pass due to the test interface and real interfaces becoming incompatible at some point in the past.

I've added considerations for additional custom suffixes that might be used to identify secret files. The default set of suffixes is still `_(SECRET|SECRET_KEY|PASSWORD|TOKEN|ACCESS_KEY)$`

