### PR TITLE
dependabot.yml: remove reviewers

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,8 +5,6 @@ updates:
     schedule:
       interval: "weekly"
     open-pull-requests-limit: 2
-    reviewers:
-      - "buildkite/agent-stewards"
     groups:
       aws:
         patterns:
@@ -15,5 +13,3 @@ updates:
     directory: /.buildkite
     schedule:
       interval: monthly
-    reviewers:
-      - "buildkite/agent-stewards"


### PR DESCRIPTION
It should default to CODEOWNERS.