### PR TITLE
Update aws sdk reference to use v2

### DIFF
--- a/s3secrets-helper/s3/s3_test.go
+++ b/s3secrets-helper/s3/s3_test.go
@@ -4,9 +4,9 @@ import (
 	"slices"
 	"testing"
 
+	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/service/s3"
 	"github.com/aws/aws-sdk-go-v2/service/s3/types"
-	"github.com/aws/aws-sdk-go/aws"
 	"github.com/awsdocs/aws-doc-sdk-examples/gov2/testtools"
 	s3client "github.com/buildkite/elastic-ci-stack-s3-secrets-hooks/s3secrets-helper/v2/s3"
 )


### PR DESCRIPTION
Update the s3 tests' reference of AWS SDK to use V2 and renamed back the s3 client to `Client` for consistency with how it is called across the plugin.