### PR TITLE
Ensure that secret files in path are retrieved from `s3://{bucket_name}/secret-files/` path

### DIFF
--- a/s3secrets-helper/secrets/secrets.go
+++ b/s3secrets-helper/secrets/secrets.go
@@ -144,10 +144,22 @@ func getSecrets(conf Config, results chan<- getResult) {
 		"_TOKEN",
 		"_ACCESS_KEY",
 	}...)
-	secretPrefix := conf.Prefix + "/secret-files"
-	keys, err := conf.Client.ListSuffix(secretPrefix, suffixes)
-	if err != nil {
-		fmt.Errorf("listing matching secrets: %w", err)
+
+	prefixes := []string{
+		conf.Prefix + "/secret-files",
+		"secret-files",
+	}
+
+	conf.Logger.Printf("Checking S3 for secret-files")
+	keys := []string{}
+	for _, p := range prefixes {
+		conf.Logger.Printf("- %s", p)
+		files, err := conf.Client.ListSuffix(p, suffixes)
+		if err != nil {
+			fmt.Errorf("listing matching secrets: %w", err)
+			continue
+		}
+		keys = append(keys, files...)
 	}
 	go GetAll(conf.Client, conf.Client.Bucket(), keys, results)
 }

--- a/s3secrets-helper/secrets/secrets_test.go
+++ b/s3secrets-helper/secrets/secrets_test.go
@@ -46,8 +46,17 @@ func (c *FakeClient) Bucket() string {
 }
 
 func (c *FakeClient) ListSuffix(prefix string, suffix []string) ([]string, error) {
-	fakeSecrets := []string{"pipeline/secret-files/BUILDKITE_ACCESS_KEY", "pipeline/secret-files/DATABASE_SECRET", "pipeline/secret-files/EXTERNAL_API_SECRET_KEY", "pipeline/secret-files/PRIVILEGED_PASSWORD", "pipeline/secret-files/SERVICE_TOKEN"}
-	return fakeSecrets, nil
+	if prefix == "pipeline/secret-files" {
+		fakeSecrets := []string{"pipeline/secret-files/BUILDKITE_ACCESS_KEY", "pipeline/secret-files/DATABASE_SECRET",
+			"pipeline/secret-files/EXTERNAL_API_SECRET_KEY", "pipeline/secret-files/PRIVILEGED_PASSWORD", "pipeline/secret-files/SERVICE_TOKEN"}
+		return fakeSecrets, nil
+	}
+
+	if prefix == "secret-files" {
+		fakeSecrets := []string{"secret-files/ORG_SERVICE_TOKEN"}
+		return fakeSecrets, nil
+	}
+	return nil, nil
 }
 
 func (c *FakeClient) Region() string {
@@ -111,6 +120,7 @@ func TestRun(t *testing.T) {
 		"bkt/pipeline/secret-files/EXTERNAL_API_SECRET_KEY": {[]byte("external api secret"), nil},
 		"bkt/pipeline/secret-files/PRIVILEGED_PASSWORD":     {[]byte("privileged password"), nil},
 		"bkt/pipeline/secret-files/SERVICE_TOKEN":           {[]byte("service token"), nil},
+		"bkt/secret-files/ORG_SERVICE_TOKEN":                {[]byte("org service token"), nil},
 	}
 	logbuf := &bytes.Buffer{}
 	fakeAgent := &FakeAgent{t: t}
@@ -155,6 +165,7 @@ func TestRun(t *testing.T) {
 		"EXTERNAL_API_SECRET_KEY='external api secret'",
 		"PRIVILEGED_PASSWORD='privileged password'",
 		"SERVICE_TOKEN='service token'",
+		"ORG_SERVICE_TOKEN='org service token'",
 	}, "\n") + "\n"
 
 	if actual := envSink.String(); expected != actual {


### PR DESCRIPTION
If the `secret-files` are specified under the path `s3://{bucket_name}/secret-files/`, these currently do not get included into the list of secret environment variables set. 