### PR TITLE
Update to use OIDC session tokens on AWS role assumption

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -80,8 +80,12 @@ steps:
   - label: "㊙️ git-credentials test"
     command: .buildkite/test_credentials.sh
     plugins:
-      - aws-assume-role-with-web-identity#v1.1.0:
+      - aws-assume-role-with-web-identity#v1.4.0:
           role-arn: arn:aws:iam::172840064832:role/pipeline-buildkite-aws-stack-elastic-ci-stack-s3-secrets-hooks
+          session-tags:
+            - organization_slug
+            - organization_id
+            - pipeline_slug
 
   - wait
 
@@ -99,8 +103,13 @@ steps:
     branches:
       - main
     plugins:
-      - aws-assume-role-with-web-identity#v1.1.0:
+      - aws-assume-role-with-web-identity#v1.4.0:
           role-arn: arn:aws:iam::172840064832:role/pipeline-elastic-ci-stack-s3-secrets-hooks-main
+          session-tags:
+            - organization_slug
+            - organization_id
+            - pipeline_slug
+            - build_branch
       - aws-ssm#v1.0.0:
           parameters:
             GITHUB_RELEASE_ACCESS_TOKEN: /pipelines/buildkite-aws-stack/elastic-ci-stack-s3-secrets-hooks/GITHUB_RELEASE_ACCESS_TOKEN


### PR DESCRIPTION
Roll out using session tags for OIDC assumable IAM role trust policy.

Follow on from the work to support session tags in https://github.com/buildkite-plugins/aws-assume-role-with-web-identity-buildkite-plugin/pull/18

Requires matching update to the IAM role in PR: https://github.com/buildkite/aws-buildkite-dist/pull/130  to be shipped first

Note that one role is restricted to main `branch_builds` only, the other is not restricted by branch. 