### PR TITLE
Add secret redaction for all secrets using `buildkite-agent redactor`

### DIFF
--- a/.buildkite/docker-compose.yml
+++ b/.buildkite/docker-compose.yml
@@ -11,6 +11,13 @@ services:
     environment:
       - GOOS
       - GOARCH
+  tests:
+    build:
+      context: .
+      dockerfile: Dockerfile-compile
+    volumes:
+      - ../:/work:cached
+    working_dir: /work
   release:
     build:
       dockerfile: Dockerfile-release

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -72,10 +72,12 @@ steps:
 
   - wait
 
-  - label: ":bash: :hammer:"
+  - label: ":go: Unit Tests"
     plugins:
-      docker-compose#v2.2.0:
+      docker-compose#v5.10.0:
+        config: .buildkite/docker-compose.yml
         run: tests
+    command: .buildkite/steps/tests.sh
 
   - label: "㊙️ git-credentials test"
     command: .buildkite/test_credentials.sh

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -122,16 +122,11 @@ steps:
           env:
             - GITHUB_RELEASE_ACCESS_TOKEN
 
-  - label: ":shell: Tests"
+  - label: ":shell: Plugin Tests"
     plugins:
       - plugin-tester#v1.2.0:
           folders:
             - tests
-
-  - label: ":sparkles: Lint"
-    plugins:
-      - plugin-linter#v3.3.0:
-          id: elastic-ci-stack-s3-secrets-hooks
 
   - label: ":shell: Shellcheck"
     plugins:

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -122,3 +122,19 @@ steps:
           env:
             - GITHUB_RELEASE_ACCESS_TOKEN
 
+  - label: ":shell: Tests"
+    plugins:
+      - plugin-tester#v1.2.0:
+          folders:
+            - tests
+
+  - label: ":sparkles: Lint"
+    plugins:
+      - plugin-linter#v3.3.0:
+          id: elastic-ci-stack-s3-secrets-hooks
+
+  - label: ":shell: Shellcheck"
+    plugins:
+      - shellcheck#v1.4.0:
+          files:
+            - hooks/**

--- a/.buildkite/steps/tests.sh
+++ b/.buildkite/steps/tests.sh
@@ -1,0 +1,22 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+echo "--- Running Go tests"
+
+cd s3secrets-helper
+
+go version
+echo arch is "$(uname -m)"
+
+go install gotest.tools/gotestsum@v1.8.0
+
+mkdir -p coverage
+COVERAGE_DIR="$PWD/coverage"
+
+if [[ "$(go env GOOS)" == "windows" ]]; then
+  gotestsum --junitfile="junit-${BUILDKITE_JOB_ID:-local}.xml" -- -count=1 -race ./...
+else
+  gotestsum --junitfile="junit-${BUILDKITE_JOB_ID:-local}.xml" -- -count=1 -race -cover -test.gocoverdir="${COVERAGE_DIR}" ./...
+fi
+
+echo "--- Go tests completed successfully"

--- a/.buildkite/steps/tests.sh
+++ b/.buildkite/steps/tests.sh
@@ -10,13 +10,10 @@ echo arch is "$(uname -m)"
 
 go install gotest.tools/gotestsum@v1.8.0
 
-mkdir -p coverage
-COVERAGE_DIR="$PWD/coverage"
-
 if [[ "$(go env GOOS)" == "windows" ]]; then
   gotestsum --junitfile="junit-${BUILDKITE_JOB_ID:-local}.xml" -- -count=1 -race ./...
 else
-  gotestsum --junitfile="junit-${BUILDKITE_JOB_ID:-local}.xml" -- -count=1 -race -cover -test.gocoverdir="${COVERAGE_DIR}" ./...
+  gotestsum --junitfile="junit-${BUILDKITE_JOB_ID:-local}.xml" -- -count=1 -race -cover ./...
 fi
 
 echo "--- Go tests completed successfully"

--- a/README.md
+++ b/README.md
@@ -69,6 +69,12 @@ The private key is exposed to both the checkout and the command as an ssh-agent 
 The secrets in the env file are exposed as environment variables, as are individual secret files.
 The locations of git-credentials are passed via `GIT_CONFIG_PARAMETERS` environment to git.
 
+## Secret Redaction
+
+When using Buildkite Agent v3.67.0 or later, secrets are automatically redacted from build logs to prevent accidental exposure. The plugin will detect the agent version and use the built-in redactor feature when available.
+
+For agents running older versions, a warning will be displayed recommending an upgrade for enhanced security.
+
 ## Uploading Secrets
 
 ### SSH Keys

--- a/hooks/environment
+++ b/hooks/environment
@@ -3,20 +3,37 @@ set -e -o pipefail -u
 
 basedir="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && cd .. && pwd )"
 credhelper="$basedir/git-credential-s3-secrets"
+envscript_file=$(mktemp)
+
+# Ensure cleanup on exit, even if something fails
+trap 'rm -f "$envscript_file"' EXIT
 
 # s3secrets-helper must be in PATH
-envscript="$(
-  BUILDKITE_PLUGIN_S3_SECRETS_CREDHELPER="$credhelper" \
-    s3secrets-helper
-)"
+if ! BUILDKITE_PLUGIN_S3_SECRETS_CREDHELPER="$credhelper" s3secrets-helper > "$envscript_file"; then
+  echo "Error: s3secrets-helper failed" >&2
+  exit 1
+fi
 
 env_before="$(env | sort)"
-echo "Evaluating ${#envscript} bytes of env"
+envscript_size=$(wc -c < "$envscript_file")
+echo "Evaluating $envscript_size bytes of env from temporary file"
 set -o allexport
-eval "$envscript"
+source "$envscript_file"
 set +o allexport
 
 if [[ "${BUILDKITE_PLUGIN_S3_SECRETS_DUMP_ENV:-}" =~ ^(true|1)$ ]] ; then
   echo "~~~ Environment variables that were set" >&2;
-  comm -13 <(echo "$env_before") <(env | sort) || true
+
+  # Use temporary files to avoid ARG_MAX "Argument list too long" errors with massive secret datasets
+  env_before_file=$(mktemp)
+  env_after_file=$(mktemp)
+
+  # Ensure cleanup of these temp files too
+  trap 'rm -f "$envscript_file" "$env_before_file" "$env_after_file"' EXIT
+
+  echo "$env_before" > "$env_before_file"
+  env | sort > "$env_after_file"
+
+  # Use comm with files instead of process substitution to handle large datasets
+  comm -13 "$env_before_file" "$env_after_file" || true
 fi

--- a/hooks/environment
+++ b/hooks/environment
@@ -3,37 +3,20 @@ set -e -o pipefail -u
 
 basedir="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && cd .. && pwd )"
 credhelper="$basedir/git-credential-s3-secrets"
-envscript_file=$(mktemp)
-
-# Ensure cleanup on exit, even if something fails
-trap 'rm -f "$envscript_file"' EXIT
 
 # s3secrets-helper must be in PATH
-if ! BUILDKITE_PLUGIN_S3_SECRETS_CREDHELPER="$credhelper" s3secrets-helper > "$envscript_file"; then
-  echo "Error: s3secrets-helper failed" >&2
-  exit 1
-fi
+envscript="$(
+  BUILDKITE_PLUGIN_S3_SECRETS_CREDHELPER="$credhelper" \
+    s3secrets-helper
+)"
 
 env_before="$(env | sort)"
-envscript_size=$(wc -c < "$envscript_file")
-echo "Evaluating $envscript_size bytes of env from temporary file"
+echo "Evaluating ${#envscript} bytes of env"
 set -o allexport
-source "$envscript_file"
+eval "$envscript"
 set +o allexport
 
 if [[ "${BUILDKITE_PLUGIN_S3_SECRETS_DUMP_ENV:-}" =~ ^(true|1)$ ]] ; then
   echo "~~~ Environment variables that were set" >&2;
-
-  # Use temporary files to avoid ARG_MAX "Argument list too long" errors with massive secret datasets
-  env_before_file=$(mktemp)
-  env_after_file=$(mktemp)
-
-  # Ensure cleanup of these temp files too
-  trap 'rm -f "$envscript_file" "$env_before_file" "$env_after_file"' EXIT
-
-  echo "$env_before" > "$env_before_file"
-  env | sort > "$env_after_file"
-
-  # Use comm with files instead of process substitution to handle large datasets
-  comm -13 "$env_before_file" "$env_after_file" || true
+  comm -13 <(echo "$env_before") <(env | sort) || true
 fi

--- a/s3secrets-helper/env/env.go
+++ b/s3secrets-helper/env/env.go
@@ -1,11 +1,11 @@
 package env
 
 const (
-	EnvBucket     = "BUILDKITE_PLUGIN_S3_SECRETS_BUCKET"
-	EnvRegion     = "BUILDKITE_PLUGIN_S3_SECRETS_REGION"
-	EnvPrefix     = "BUILDKITE_PLUGIN_S3_SECRETS_BUCKET_PREFIX"
-	EnvPipeline   = "BUILDKITE_PIPELINE_SLUG"
-	EnvRepo       = "BUILDKITE_REPO"
-	EnvCredHelper = "BUILDKITE_PLUGIN_S3_SECRETS_CREDHELPER"
+	EnvBucket                    = "BUILDKITE_PLUGIN_S3_SECRETS_BUCKET"
+	EnvRegion                    = "BUILDKITE_PLUGIN_S3_SECRETS_REGION"
+	EnvPrefix                    = "BUILDKITE_PLUGIN_S3_SECRETS_BUCKET_PREFIX"
+	EnvPipeline                  = "BUILDKITE_PIPELINE_SLUG"
+	EnvRepo                      = "BUILDKITE_REPO"
+	EnvCredHelper                = "BUILDKITE_PLUGIN_S3_SECRETS_CREDHELPER"
 	EnvSkipSSHKeyNotFoundWarning = "BUILDKITE_PLUGIN_S3_SECRETS_SKIP_SSH_KEY_NOT_FOUND_WARNING"
 )

--- a/s3secrets-helper/go.mod
+++ b/s3secrets-helper/go.mod
@@ -26,4 +26,5 @@ require (
 	github.com/aws/aws-sdk-go-v2/service/sso v1.27.0 // indirect
 	github.com/aws/aws-sdk-go-v2/service/ssooidc v1.32.0 // indirect
 	github.com/aws/aws-sdk-go-v2/service/sts v1.36.0 // indirect
+	github.com/joho/godotenv v1.5.1 // indirect
 )

--- a/s3secrets-helper/go.sum
+++ b/s3secrets-helper/go.sum
@@ -38,3 +38,5 @@ github.com/aws/smithy-go v1.22.5 h1:P9ATCXPMb2mPjYBgueqJNCA5S9UfktsW0tTxi+a7eqw=
 github.com/aws/smithy-go v1.22.5/go.mod h1:t1ufH5HMublsJYulve2RKmHDC15xu1f26kHCp/HgceI=
 github.com/awsdocs/aws-doc-sdk-examples/gov2/testtools v0.0.0-20250305205910-f85b847ca6da h1:+SYXpcEy9JKkpaJp9JM1pKTBIi++DnNbwykRx7MEsn8=
 github.com/awsdocs/aws-doc-sdk-examples/gov2/testtools v0.0.0-20250305205910-f85b847ca6da/go.mod h1:9Oj/8PZn3D5Ftp/Z1QWrIEFE0daERMqfJawL9duHRfc=
+github.com/joho/godotenv v1.5.1 h1:7eLL/+HRGLY0ldzfGMeQkb7vMd0as4CfYvUVzLqw0N0=
+github.com/joho/godotenv v1.5.1/go.mod h1:f4LDr5Voq0i2e/R5DDNOoa2zzDfwtkZa6DnEwAbqwq4=

--- a/s3secrets-helper/main.go
+++ b/s3secrets-helper/main.go
@@ -48,7 +48,7 @@ func mainWithError(log *log.Logger) error {
 		return fmt.Errorf("The %s environment variable is required, set it to the path of the git-credential-s3-secrets script.", env.EnvCredHelper)
 	}
 
-	return secrets.Run(secrets.Config{
+	return secrets.Run(&secrets.Config{
 		Repo:                      os.Getenv(env.EnvRepo),
 		Bucket:                    bucket,
 		Prefix:                    prefix,

--- a/s3secrets-helper/secrets/secrets.go
+++ b/s3secrets-helper/secrets/secrets.go
@@ -496,8 +496,7 @@ func redactSecrets(log *log.Logger, secrets []string) error {
 		return nil
 	}
 
-	// Clean up the secrets list by removing empty entries.
-	// We pre-allocate capacity since most secrets will be valid.
+	// Clean up the secrets list by removing empty entries
 	validSecrets := make([]string, 0, len(secrets))
 	for _, secret := range secrets {
 		if trimmed := strings.TrimSpace(secret); trimmed != "" {

--- a/s3secrets-helper/secrets/secrets_test.go
+++ b/s3secrets-helper/secrets/secrets_test.go
@@ -160,12 +160,12 @@ func TestRun(t *testing.T) {
 		// because git-credentials were found:
 		// (wrap in double quotes so that bash eval doesn't consume the inner single quote.
 		`GIT_CONFIG_PARAMETERS="` + gitCredentialHelpers + `"`,
-		"ORG_SERVICE_TOKEN='org service token'",
-		"BUILDKITE_ACCESS_KEY='buildkite access key'",
-		"DATABASE_SECRET='database secret'",
-		"EXTERNAL_API_SECRET_KEY='external api secret'",
-		"PRIVILEGED_PASSWORD='privileged password'",
-		"SERVICE_TOKEN='service token'",
+		`ORG_SERVICE_TOKEN="org service token"`,
+		`BUILDKITE_ACCESS_KEY="buildkite access key"`,
+		`DATABASE_SECRET="database secret"`,
+		`EXTERNAL_API_SECRET_KEY="external api secret"`,
+		`PRIVILEGED_PASSWORD="privileged password"`,
+		`SERVICE_TOKEN="service token"`,
 	}, "\n") + "\n"
 
 	if actual := envSink.String(); expected != actual {

--- a/s3secrets-helper/secrets/secrets_test.go
+++ b/s3secrets-helper/secrets/secrets_test.go
@@ -136,7 +136,7 @@ func TestRun(t *testing.T) {
 		EnvSink:             envSink,
 		GitCredentialHelper: "/path/to/git-credential-s3-secrets",
 	}
-	if err := secrets.Run(conf); err != nil {
+	if err := secrets.Run(&conf); err != nil {
 		t.Error(err)
 	}
 
@@ -189,7 +189,7 @@ func TestNoneFound(t *testing.T) {
 		SSHAgent: fakeAgent,
 		EnvSink:  envSink,
 	}
-	if err := secrets.Run(conf); err != nil {
+	if err := secrets.Run(&conf); err != nil {
 		t.Error(err)
 	}
 	assertDeepEqual(t, []string{}, fakeAgent.keys)
@@ -219,7 +219,7 @@ func TestNoneFoundWithDisabledWarning(t *testing.T) {
 		EnvSink:                   envSink,
 		SkipSSHKeyNotFoundWarning: true,
 	}
-	if err := secrets.Run(conf); err != nil {
+	if err := secrets.Run(&conf); err != nil {
 		t.Error(err)
 	}
 	assertDeepEqual(t, []string{}, fakeAgent.keys)

--- a/s3secrets-helper/sshagent/sshagent.go
+++ b/s3secrets-helper/sshagent/sshagent.go
@@ -32,9 +32,11 @@ type Agent struct {
 // If ssh-agent has already been started, do nothing.
 // If SSH_AUTH_SOCK & SSH_AGENT_PID are set, adopt those.
 // Otherwise, start an ssh-agent, which produces output like:
-//     SSH_AUTH_SOCK=/path/to/socket; export SSH_AUTH_SOCK;
-//     SSH_AGENT_PID=42; export SSH_AGENT_PID;
-//     echo Agent pid 42
+//
+//	SSH_AUTH_SOCK=/path/to/socket; export SSH_AUTH_SOCK;
+//	SSH_AGENT_PID=42; export SSH_AGENT_PID;
+//	echo Agent pid 42
+//
 // The output is captured verbatim, and also parsed for those values.
 // The SSH_AUTH_SOCK in either case is used for subsequent Add()
 // The bool return value indicates whether the call started the agent.

--- a/tests/environment.bats
+++ b/tests/environment.bats
@@ -1,6 +1,11 @@
 #!/usr/bin/env bats
 
-load '/usr/local/lib/bats/load.bash'
+setup() {
+  load "${BATS_PLUGIN_PATH}/load.bash"
+  export BUILDKITE_PLUGIN_S3_SECRETS_BUCKET=my_secrets_bucket
+  export BUILDKITE_PLUGIN_S3_SECRETS_DUMP_ENV=true
+  export BUILDKITE_PIPELINE_SLUG=test
+}
 
 # export AWS_STUB_DEBUG=/dev/tty
 # export SSH_ADD_STUB_DEBUG=/dev/tty
@@ -8,10 +13,6 @@ load '/usr/local/lib/bats/load.bash'
 # export GIT_STUB_DEBUG=/dev/tty
 
 @test "delegating to go binary" {
-  export BUILDKITE_PLUGIN_S3_SECRETS_BUCKET=my_secrets_bucket
-  export BUILDKITE_PLUGIN_S3_SECRETS_DUMP_ENV=true
-  export BUILDKITE_PIPELINE_SLUG=test
-
   stub s3secrets-helper \
     ": echo -e \"A=hello\nB=world\necho Agent pid 42\n\""
 


### PR DESCRIPTION
Adds automatic secret redaction to prevent secrets from appearing in build logs. Uses `buildkite-agent redactor` to register all S3 secrets for redaction before they can be logged.

- Collects all secrets from S3 during the normal fetch process
- Sends secrets to `buildkite-agent redactor add` using JSON batch format
- Splits large secret lists into chunks to handle builds with lots of secrets
- Detects agent version and gracefully handles older versions that don't support redaction
- Provides warnings when redaction is unavailable
