### PR TITLE
Set go version base to 1.26

### DIFF
--- a/s3secrets-helper/go.mod
+++ b/s3secrets-helper/go.mod
@@ -1,6 +1,6 @@
 module github.com/buildkite/elastic-ci-stack-s3-secrets-hooks/s3secrets-helper/v2
 
-go 1.26.4
+go 1.26
 
 require (
 	github.com/aws/aws-sdk-go-v2 v1.41.9


### PR DESCRIPTION
https://github.com/buildkite/elastic-ci-stack-s3-secrets-hooks/pull/174 set the go version to `1.26.4`. Dropping back down to `1.26`.